### PR TITLE
Requires GHC >= 7.4 due to usage of Data.Monoid.<>

### DIFF
--- a/pseudo-trie.cabal
+++ b/pseudo-trie.cabal
@@ -15,7 +15,7 @@ Library
   GHC-Options:          -Wall
   Exposed-Modules:      Data.Trie.Pseudo
                         Data.Trie.Rooted
-  Build-Depends:        base >= 4 && < 5
+  Build-Depends:        base >= 4.5 && < 5
                       , semigroups
 
 Source-Repository head


### PR DESCRIPTION
```
src/Data/Trie/Rooted.hs:58:23:
    Not in scope: `<>'
    Perhaps you meant one of these:
      `<$>' (imported from Control.Applicative),
      `<*>' (imported from Control.Applicative),
      `<|>' (imported from Control.Applicative)

src/Data/Trie/Rooted.hs:68:29:
    Not in scope: `<>'
    Perhaps you meant one of these:
      `<$>' (imported from Control.Applicative),
      `<*>' (imported from Control.Applicative),
      `<|>' (imported from Control.Applicative)
xcabal: Error: some packages failed to install:
pseudo-trie-0.0.4.3 failed during the building phase. The exception was:
ExitFailure 1
```

I've published [new revisions for affected versions on hackage](https://hackage.haskell.org/package/pseudo-trie-0.0.4.3/revisions/) so a new release is only necessary if you wish to restore GHC < 7.4 compatibility.
